### PR TITLE
Use hspec for the test suite

### DIFF
--- a/sil.cabal
+++ b/sil.cabal
@@ -60,6 +60,7 @@ test-suite sil-test
   main-is:             Spec.hs
   other-modules:       Common
   build-depends:       base
+                     , hspec
                      , sil
                      , strict
                      , QuickCheck


### PR DESCRIPTION
The current hand-rolled test suite is somewhat inconvenient to use since it is completely silent and therefore gives you no indication if a test hangs or whether there are just a lot of tests, …. By switching to hspec we get a nice output of the individual tests as they are being run and we also get nice features like selectively running only a few tests.