### PR TITLE
Use AggregateZero to initialize array

### DIFF
--- a/src/SIL/Llvm.hs
+++ b/src/SIL/Llvm.hs
@@ -222,7 +222,7 @@ pairHeap = GlobalDefinition
   $ globalVariableDefaults
   { name = heapN
   , LLVM.AST.Global.type' = heapType
-  , initializer = Just (C.Array pairT . take (fromIntegral heapSize) $ repeat emptyPair)
+  , initializer = Just (C.AggregateZero heapType)
   }
 
 heapIndexN :: Name


### PR DESCRIPTION
This cuts down the time needed to create the LLVM module significantly since we no longer end up creating a giant array.