### PR TITLE
Add time tracking for compilation and execution

### DIFF
--- a/sil.cabal
+++ b/sil.cabal
@@ -31,6 +31,7 @@ library
                      , recursion-schemes
                      , parsec
                      , indents
+                     , clock
                      , containers
                      , mtl
                      , vector


### PR DESCRIPTION
Currently we track time for the following phases:

1. Serialization the Haskell AST to the C++ representation.
2. Running the LLVM optimizer.
3. Adding the module to the JIT compiler.
4. Running the JIT-compiled module.

When the optimizer is turned off, the bottleneck is clearly the part where we add the module to the JIT compiler probably just due to the sheer size of some of these modules. The runtime is always smaller than `0.1s` (and for most tests even smaller than `0.01s`). The optimizer at level 2 takes about as much time as adding the module. The time taken to the serialize the module is significant but always significantly factor than the time of adding the module (by a factor of ~3 on average maybe) so that’s not the bottleneck.

Overall, my takeway so far is that we probably need to focus on limiting the size of the modules that are being generated.