### PR TITLE
Implement hashing of NExpr and deduplicate LLVM functions

### DIFF
--- a/sil.cabal
+++ b/sil.cabal
@@ -30,6 +30,9 @@ library
                      , SIL.Serializer
                      , SIL.Serializer.C
   build-depends:       base >= 4.7 && < 5
+                     , base16-bytestring
+                     , binary
+                     , cryptohash-sha256
                      , recursion-schemes
                      , parsec
                      , indents

--- a/src/Naturals.hs
+++ b/src/Naturals.hs
@@ -2,6 +2,7 @@
 {-#LANGUAGE DeriveAnyClass#-}
 module Naturals where
 
+import Data.Binary
 import Data.Int (Int64)
 import Control.DeepSeq
 import GHC.Generics
@@ -31,6 +32,8 @@ data NExpr
   | NPow NExpr NExpr
   | NITE NExpr NExpr NExpr
   deriving (Eq, Show, Ord, Generic, NFData)
+
+instance Binary NExpr
 
 {-
 data NZeroType


### PR DESCRIPTION
We use the generic Binary instances to serialize the NExpr to a
ByteString and then take the sha256 hash of that value.