### PR TITLE
Simple REPL

### DIFF
--- a/app/MiniRepl.hs
+++ b/app/MiniRepl.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE TupleSections #-}
+module Main where
+
+import System.Console.Haskeline
+
+import Text.Parsec.Error (ParseError)
+import Text.Parsec 
+
+import Text.Parsec.Indent
+
+import SIL.Parser
+import SIL.RunTime
+import SIL
+
+import Control.Monad.IO.Class
+import Data.List
+
+import qualified Data.Map         as Map
+import qualified System.IO.Strict as Strict
+
+-- REPL parsing
+
+addReplBound :: String -> Term1 -> ParserState -> ParserState
+addReplBound name expr (ParserState bound) = ParserState (Map.insert name expr bound)
+
+parseReplAssignment :: SILParser ()
+parseReplAssignment = do
+  var <- identifier
+  annotation <- optionMaybe parseRefinementCheck
+  reservedOp "=" <?> "assignment ="
+  expr <- parseLongExpr
+  let annoExp = case annotation of
+        Just f -> f expr
+        _ -> expr
+      assign ps = addReplBound var annoExp ps 
+  modifyState assign
+
+parseReplExpr :: SILParser ()
+parseReplExpr = do
+  expr <- parseLongExpr
+  let assign ps = addReplBound "_tmp_" expr ps 
+  modifyState assign
+
+data ReplStep = ReplAssignment
+              | ReplExpr
+
+parseReplStep :: SILParser (ReplStep, Bindings)
+parseReplStep =  step >>= (\x -> (x,) <$> (bound <$> getState)) 
+    where step = try (parseReplAssignment *> return ReplAssignment)
+               <|>   (parseReplExpr       *> return ReplExpr)
+
+runReplParser :: Bindings -> String -> Either ParseError (ReplStep, Bindings)
+runReplParser prelude = let startState = ParserState prelude
+                        in runIndentParser parseReplStep startState "sil"
+
+-- Repl loop
+
+data ReplState = ReplState Bindings
+
+replStep :: Bindings -> String -> InputT IO Bindings
+replStep bindings s = do
+    let e_new_bindings = runReplParser bindings s
+    case e_new_bindings of
+        Left err -> do 
+            outputStrLn $ "Parse error: " ++ show err
+            return bindings
+        Right (ReplExpr,new_bindings) -> do  
+            case Map.lookup "_tmp_" new_bindings of
+                Nothing -> outputStrLn "Could not find _tmp_ in bindings"
+                Just e  -> do
+                    iexpr <- convertPT <$> debruijinize [] e 
+                    e_iexpr <- liftIO $ simpleEval iexpr
+                    outputStrLn $ (show.PrettyIExpr) e_iexpr
+            return bindings
+        Right (ReplAssignment, new_bindings) -> do
+            return new_bindings
+            
+
+replMultiline :: [String] -> InputT IO String
+replMultiline buffer = do
+    minput <- getInputLine ""
+    case minput of
+        Nothing -> return ""
+        Just ":}" -> return $ concat $ intersperse "\n" $ reverse buffer
+        Just s    -> replMultiline (s : buffer) 
+
+
+replLoop :: ReplState -> InputT IO ()
+replLoop (ReplState bs) = do 
+    minput <- getInputLine "sil> "
+    case minput of
+        Nothing   -> return ()
+        Just ":{" -> replLoop =<< (ReplState <$> (replStep bs =<< replMultiline [])) 
+        Just s    -> replLoop =<< (ReplState <$> replStep bs s)
+
+main = do
+    e_prelude <- parsePrelude <$> Strict.readFile "Prelude.sil" 
+    let bindings = case e_prelude of
+            Left  _   -> Map.empty
+            Right bds -> bds
+    runInputT defaultSettings $ replLoop (ReplState bindings)

--- a/app/MiniRepl.hs
+++ b/app/MiniRepl.hs
@@ -69,9 +69,12 @@ replStep bindings s = do
             case Map.lookup "_tmp_" new_bindings of
                 Nothing -> outputStrLn "Could not find _tmp_ in bindings"
                 Just e  -> do
-                    iexpr <- convertPT <$> debruijinize [] e 
-                    e_iexpr <- liftIO $ simpleEval iexpr
-                    outputStrLn $ (show.PrettyIExpr) e_iexpr
+                    let m_iexpr = convertPT <$> debruijinize [] e 
+                    case m_iexpr of
+                        Nothing     -> outputStrLn "conversion error"
+                        Just iexpr' -> do
+                            iexpr <- liftIO $ simpleEval iexpr' 
+                            outputStrLn $ (show.PrettyIExpr) iexpr
             return bindings
         Right (ReplAssignment, new_bindings) -> do
             return new_bindings

--- a/bench/MemoryBench.hs
+++ b/bench/MemoryBench.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -30,6 +31,8 @@ import Text.Parsec.Error (ParseError)
 
 import Debug.Trace
 
+foreign import capi "gc.h GC_INIT" gcInit :: IO ()
+foreign import ccall "gc.h GC_allow_register_threads" gcAllowRegisterThreads :: IO ()
 -- TODO:
 -- Get some expressions/groups of expressions.
 -- Measure memory needed to:
@@ -75,6 +78,8 @@ config :: Config
 config = Config [Weigh.Case, Allocated, GCs, Live] "" Plain
 
 main = do
+  gcInit
+  gcAllowRegisterThreads
   preludeFile <- Strict.readFile "Prelude.sil"
 
   let

--- a/sil.cabal
+++ b/sil.cabal
@@ -73,6 +73,7 @@ executable sil-mini-repl
                      , parsec
                      , indents
                      , strict 
+                     , optparse-applicative
   default-language:    Haskell2010
 
 test-suite sil-test

--- a/sil.cabal
+++ b/sil.cabal
@@ -19,8 +19,8 @@ library
   hs-source-dirs:      src
   include-dirs:        cbits/include
   c-sources:           cbits/SIL.c
-  exposed-modules:     SIL
-                     , Naturals
+  exposed-modules:     Naturals
+                     , SIL
                      , SIL.Eval
                      , SIL.Llvm
                      , SIL.Optimizer
@@ -55,6 +55,19 @@ executable sil-exe
                      , containers
                      , sil
                      , strict
+  default-language:    Haskell2010
+
+executable sil-mini-repl
+  hs-source-dirs:      app
+  main-is:             MiniRepl.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , containers
+                     , sil
+                     , haskeline
+                     , parsec
+                     , indents
+                     , strict 
   default-language:    Haskell2010
 
 test-suite sil-test


### PR DESCRIPTION
Added a simple REPL. Supports assignment, evaluation of expressions, and multiline assignments/expressions.

```
sil> plus $1 $2 succ 0
...
sil> var = {1,2}
sil> :{
let a = $3
    b = $3
in plus a b succ 0
:}
...
``` 